### PR TITLE
Logic Fix To - Admin Match Update

### DIFF
--- a/server/routes/admin-match.js
+++ b/server/routes/admin-match.js
@@ -27,6 +27,9 @@ router.post('/match/update', passport.authenticate('jwt', {
                 homeDominate = true;
             } else if (match.home.score == 0 && match.away.score == 2) {
                 awayDominate = true;
+            } else {
+                match.home.dominator = false;
+                match.away.dominator = false;
             }
             if (homeDominate) {
                 if (util.returnBoolByPath(match, 'away.dominator')) {


### PR DESCRIPTION
update the admin match updater so that if the admin changes a match that PREVIOUSLY HAD A DOMINATOR FLAG to a condition that should not have a dominator, the flag will be removed.